### PR TITLE
Fix clarity of backend packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ Please see [README.md](./custompios/README.md) in the module folder for further 
 
 ---
 
-## What 'Backends' uses crowsnest?
+## What 'Backends' does crowsnest use?
 
 - ustreamer - A streamserver from Pi-KVM project \
   active maintained by [Maxim Devaev](https://github.com/mdevaev) \


### PR DESCRIPTION
Make it clear that crowsnest uses these two packages instead of how it was written, implying that the packages used crowsnest.